### PR TITLE
BE-472 #Done Put Errors in the status stream in JsoupParser Bolt

### DIFF
--- a/jsoup-parser/build.gradle
+++ b/jsoup-parser/build.gradle
@@ -35,7 +35,8 @@ dependencies {
     compile (
         [group:'org.jsoup',                  name:'jsoup',                  version:'1.8.1'],
         [group:'org.slf4j',                  name:'slf4j-api',              version:'1.7.7'],
-        [group:'com.ibm.icu',                name:'icu4j',                  version:'54.1.1']
+        [group:'com.ibm.icu',                name:'icu4j',                  version:'54.1.1'],
+        [group:'org.apache.commons',         name:'commons-lang3',          version:'3.3.2']
     )
 }
 


### PR DESCRIPTION
Currently the error handling of the JSoupParserBolt is incorrect, It is currently doing a collector.fail,
unfortunately this just resends the same tuple over and over again when we do this.

A better solution would be to send the crawlStatus through the status stream to the CrawlItemUpdater.
The crawlItemUpdater will then save the status to dynamoDB with a status of error.