### PR TITLE
Minor improvements to the JSoupParserBolt

### DIFF
--- a/jsoup-parser/src/main/java/com/shopstyle/crawler/jsoup/JSoupParserBolt.java
+++ b/jsoup-parser/src/main/java/com/shopstyle/crawler/jsoup/JSoupParserBolt.java
@@ -4,22 +4,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.entity.ContentType;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.DocumentFragment;
-import org.w3c.dom.Node;
 
 import backtype.storm.metric.api.MultiCountMetric;
 import backtype.storm.task.OutputCollector;
@@ -42,6 +31,17 @@ import com.digitalpebble.storm.crawler.util.MetadataTransfer;
 import com.ibm.icu.text.CharsetDetector;
 import com.ibm.icu.text.CharsetMatch;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.entity.ContentType;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.DocumentFragment;
+
+import static com.digitalpebble.storm.crawler.Constants.StatusStreamName;
+
 /**
  * Simple parser for HTML documents which calls ParseFilters to add metadata. Does not handle
  * outlinks for now.
@@ -49,8 +49,10 @@ import com.ibm.icu.text.CharsetMatch;
 @SuppressWarnings("serial")
 public class JSoupParserBolt extends BaseRichBolt {
 
-    private static final String ERROR_MESSAGE = "errorMessage";
-    private final Logger log = LoggerFactory.getLogger(JSoupParserBolt.class);
+    /** Metadata key name for tracking the anchors */
+    public static final String ANCHORS_KEY_NAME = "anchors";
+
+    private static final Logger LOG = LoggerFactory.getLogger(JSoupParserBolt.class);
 
     private OutputCollector collector;
 
@@ -64,14 +66,14 @@ public class JSoupParserBolt extends BaseRichBolt {
 
     private boolean trackAnchors = true;
 
-    /** Metadata key name for tracking the anchors */
-    public static final String ANCHORS_KEY_NAME = "anchors";
+    private boolean emitOutlinks = true;
 
     @Override
     public void prepare(Map conf, TopologyContext context, OutputCollector collector) {
         this.collector = collector;
 
-        eventCounter = context.registerMetric("parser_counter", new MultiCountMetric(), 10);
+        eventCounter =
+                context.registerMetric(this.getClass().getSimpleName(), new MultiCountMetric(), 10);
 
         parseFilters = ParseFilters.emptyParseFilter;
 
@@ -81,20 +83,25 @@ public class JSoupParserBolt extends BaseRichBolt {
             try {
                 parseFilters = new ParseFilters(conf, parseconfigfile);
             } catch (IOException e) {
-                log.error("Exception caught while loading the ParseFilters");
+                LOG.error("Exception caught while loading the ParseFilters");
                 throw new RuntimeException("Exception caught while loading the ParseFilters", e);
             }
         }
 
-        String urlconfigfile =
-                ConfUtils.getString(conf, "urlfilters.config.file", "urlfilters.json");
+        urlFilters = URLFilters.emptyURLFilters;
+        emitOutlinks = ConfUtils.getBoolean(conf, "parser.emitOutlinks", true);
 
-        if (urlconfigfile != null) {
-            try {
-                urlFilters = new URLFilters(conf, urlconfigfile);
-            } catch (IOException e) {
-                log.error("Exception caught while loading the URLFilters");
-                throw new RuntimeException("Exception caught while loading the URLFilters", e);
+        if (emitOutlinks) {
+            String urlconfigfile =
+                    ConfUtils.getString(conf, "urlfilters.config.file", "urlfilters.json");
+
+            if (urlconfigfile != null) {
+                try {
+                    urlFilters = new URLFilters(conf, urlconfigfile);
+                } catch (IOException e) {
+                    LOG.error("Exception caught while loading the URLFilters");
+                    throw new RuntimeException("Exception caught while loading the URLFilters", e);
+                }
             }
         }
 
@@ -110,25 +117,103 @@ public class JSoupParserBolt extends BaseRichBolt {
         String url = tuple.getStringByField("url");
         Metadata metadata = (Metadata) tuple.getValueByField("metadata");
 
-        if (content == null) {
-            log.error("Null content for {} ", url);
-            handleParsingError(tuple, "Null content for " + url, metadata, url);
+        long start = System.currentTimeMillis();
+
+        String charset = getContentCharset(content, metadata);
+
+        Map<String, List<String>> slinks;
+        String text;
+        DocumentFragment fragment;
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(content)) {
+            org.jsoup.nodes.Document jsoupDoc = Jsoup.parse(bais, charset, url);
+            fragment = DOMBuilder.jsoup2HTML(jsoupDoc);
+
+            Elements links = jsoupDoc.select("a[href]");
+            slinks = new HashMap<String, List<String>>(links.size());
+            for (Element link : links) {
+                // abs:href tells jsoup to return fully qualified domains for relative urls.
+                // e.g.: /foo will resolve to http://shopstyle.com/foo
+                String targetURL = link.attr("abs:href");
+                String anchor = link.text();
+                if (StringUtils.isNotBlank(targetURL)) {
+                    List<String> anchors = slinks.get(targetURL);
+                    if (anchors == null) {
+                        anchors = new LinkedList<String>();
+                        slinks.put(targetURL, anchors);
+                    }
+                    if (StringUtils.isNotBlank(anchor)) {
+                        anchors.add(anchor);
+                    }
+                }
+            }
+
+            text = jsoupDoc.body().text();
+
+        } catch (Throwable e) {
+            String errorMessage = "Exception while parsing " + url + ": " + e;
+            LOG.error(errorMessage);
+            // send to status stream in case another component wants to update
+            // its status
+            metadata.setValue(Constants.STATUS_ERROR_SOURCE, "content parsing");
+            metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
+            collector.emit(StatusStreamName, tuple, new Values(url, metadata, Status.ERROR));
+            collector.ack(tuple);
+            // Increment metric that is context specific
+            eventCounter.scope("error_content_parsing_" + e.getClass().getSimpleName()).incrBy(1);
+            // Increment general metric
+            eventCounter.scope("parse exception").incrBy(1);
             return;
         }
 
-        long start = System.currentTimeMillis();
+        long duration = System.currentTimeMillis() - start;
 
-        String text = "";
+        LOG.info("Parsed {} in {} msec", url, duration);
 
-        Map<String, List<String>> slinks = Collections.emptyMap();
+        // apply the parse filters if any
+        try {
+            parseFilters.filter(url, content, fragment, metadata);
+        } catch (RuntimeException e) {
+            String errorMessage = "Exception while running parse filters on " + url + ": " + e;
+            LOG.error(errorMessage);
+            metadata.setValue(Constants.STATUS_ERROR_SOURCE, "content filtering");
+            metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
+            collector.emit(StatusStreamName, tuple, new Values(url, metadata, Status.ERROR));
+            collector.ack(tuple);
+            // Increment metric that is context specific
+            eventCounter.scope("error_content_filtering_" + e.getClass().getSimpleName()).incrBy(1);
+            // Increment general metric
+            eventCounter.scope("parse exception").incrBy(1);
+            return;
+        }
 
+        if (emitOutlinks && !slinks.isEmpty()) {
+            emitOutlinks(tuple, url, metadata, slinks);
+        }
+
+        collector.emit(tuple, new Values(url, content, metadata, text.trim()));
+        collector.ack(tuple);
+        eventCounter.scope("tuple_success").incr();
+    }
+
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        // output of this module is the list of fields to index
+        // with at least the URL, text content
+        declarer.declare(new Fields("url", "content", "metadata", "text"));
+        declarer.declareStream(StatusStreamName, new Fields("url", "metadata", "status"));
+    }
+
+    private String getContentCharset(byte[] content, Metadata metadata) {
         String charset = null;
 
         // check if the server specified a charset
-        String contentType = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE);
+        String specifiedContentType = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE);
         try {
-            ContentType ct = org.apache.http.entity.ContentType.parse(contentType);
-            charset = ct.getCharset().name();
+            if (specifiedContentType != null) {
+                ContentType parsedContentType = ContentType.parse(specifiedContentType);
+                charset = parsedContentType.getCharset().name();
+            }
         } catch (Exception e) {
             charset = null;
         }
@@ -147,63 +232,18 @@ public class JSoupParserBolt extends BaseRichBolt {
         } catch (Exception e) {
             // ignore and leave the charset as-is
         }
+        return charset;
+    }
 
-        DocumentFragment fragment;
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(content)) {
-            org.jsoup.nodes.Document jsoupDoc = Jsoup.parse(bais, charset, url);
-            fragment = DOMBuilder.jsoup2HTML(jsoupDoc);
-
-            Elements links = jsoupDoc.select("a[href]");
-            slinks = new HashMap<String, List<String>>(links.size());
-            for (Element link : links) {
-                String targetURL = link.attr("abs:href");
-                String anchor = link.text();
-                if (StringUtils.isNotBlank(targetURL)) {
-                    List<String> anchors = slinks.get(targetURL);
-                    if (anchors == null) {
-                        anchors = new LinkedList<String>();
-                    }
-                    if (StringUtils.isNotBlank(anchor)) {
-                        anchors.add(anchor);
-                    }
-                    slinks.put(targetURL, anchors);
-                }
-            }
-
-            text = jsoupDoc.body().text();
-
-        } catch (Throwable e) {
-            log.error("Exception while parsing {}", url, e);
-            handleParsingError(tuple, "Exception while parsing " + url + " : " + e.getMessage(),
-                    metadata, url);
-            return;
-        }
-
-        long duration = System.currentTimeMillis() - start;
-
-        log.info("Parsed {} in {} msec", url, duration);
-
-        // apply the parse filters if any
-
-        try {
-            parseFilters.filter(url, content, fragment, metadata);
-        } catch (RuntimeException e) {
-            log.error("Error while running the parse filters with {} ", url, e);
-            handleParsingError(tuple, "Error while running the parse filters with " + url + " : "
-                    + e.getMessage(), metadata, url);
-            return;
-        }
+    private void emitOutlinks(Tuple tuple, String url, Metadata metadata, Map<String, List<String>> slinks) {
         // get the outlinks and convert them to strings (for now)
-        URL url_;
+        URL sourceUrl;
         try {
-            url_ = new URL(url);
-        } catch (MalformedURLException e1) {
-            /*
-             * we would have known by now as previous components check whether the URL is valid
-             */
-            log.error("MalformedURLException on {} ", url, e1);
-            handleParsingError(tuple, "MalformedURLException on " + url + " : " + e1.getMessage(),
-                    metadata, url);
+            sourceUrl = new URL(url);
+        } catch (MalformedURLException e) {
+            // we would have known by now as previous components check whether the URL is valid
+            LOG.error("MalformedURLException on {}", url);
+            eventCounter.scope("error_invalid_source_url").incrBy(1);
             return;
         }
 
@@ -214,7 +254,7 @@ public class JSoupParserBolt extends BaseRichBolt {
             String targetURL = linkIterator.next();
             // filter the urls
             if (urlFilters != null) {
-                targetURL = urlFilters.filter(url_, metadata, targetURL);
+                targetURL = urlFilters.filter(sourceUrl, metadata, targetURL);
                 if (targetURL == null) {
                     eventCounter.scope("outlink_filtered").incr();
                     continue;
@@ -238,36 +278,8 @@ public class JSoupParserBolt extends BaseRichBolt {
                     linkMetadata.addValues(ANCHORS_KEY_NAME, anchors);
                 }
             }
-            collector.emit(com.digitalpebble.storm.crawler.Constants.StatusStreamName, tuple,
-                    new Values(outlink, linkMetadata, Status.DISCOVERED));
-        }
-        eventCounter.scope("parsed").incr();
-        collector.emit(tuple, new Values(url, content, metadata, text.trim()));
-        collector.ack(tuple);
-    }
-
-    private void handleParsingError(Tuple tuple, String errorMessage, Metadata metadata, String url) {
-        metadata.setValue(ERROR_MESSAGE, errorMessage);
-        collector.emit(Constants.StatusStreamName, new Values(url, metadata, Status.ERROR));
-        collector.ack(tuple);
-        eventCounter.scope("failed").incr();
-    }
-
-    @Override
-    public void declareOutputFields(OutputFieldsDeclarer declarer) {
-        // output of this module is the list of fields to index
-        // with at least the URL, text content
-        declarer.declare(new Fields("url", "content", "metadata", "text"));
-        declarer.declareStream(com.digitalpebble.storm.crawler.Constants.StatusStreamName,
-                new Fields("url", "metadata", "status"));
-    }
-
-    public static void print(Node node, String indent, StringBuffer sb) {
-        sb.append(indent).append(node.getClass().getName());
-        Node child = node.getFirstChild();
-        while (child != null) {
-            print(child, indent + " ", sb);
-            child = child.getNextSibling();
+            collector.emit(StatusStreamName, tuple, new Values(outlink, linkMetadata,
+                    Status.DISCOVERED));
         }
     }
 }


### PR DESCRIPTION
- Similar to the ParserBolt, add the ability to skip the emitting of the outlinks
- Change error handling to be similar to what is done by the ParserBolt
- Minor tweaks to be in par with the ParserBolt like the name of the metrics