### PR TITLE
Catch NPE in microdata's filter() method

### DIFF
--- a/microdata-parser/src/main/java/com/shopstyle/crawler/microdata/MicrodataFilter.java
+++ b/microdata-parser/src/main/java/com/shopstyle/crawler/microdata/MicrodataFilter.java
@@ -47,7 +47,7 @@ public class MicrodataFilter implements ParseFilter {
         MicrodataParserReport report;
         try {
             report = getMicrodata(doc);
-        } catch (MicrodataParserException e) {
+        } catch (MicrodataParserException|NullPointerException e) {
             log.error("Error parsing microdata {}", URL, e);
             return;
         }


### PR DESCRIPTION
A null `DocumentFragment` would previously break the `filter()` method, causing all `ParseFilters` to fail. This would happen for XML sitemaps, causing the `SiteMapParserBolt` to fail before emitting any outlinks, sending the URL down the status stream with a `Status.ERROR`. 